### PR TITLE
Basic support for standard queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Features
 
+* Standard queries implemented for Postgres
+
 ## Bugfixes
 
 ## Other

--- a/src/bin/dbc.rs
+++ b/src/bin/dbc.rs
@@ -34,9 +34,15 @@ fn main() -> Result<()> {
     };
 
     let mut completions: Vec<String> = tables.iter().map(|x| x.name.clone()).collect();
+    let mut query_completions: Vec<String> = conn
+        .standard_queries()
+        .iter()
+        .map(|q| q.name.to_string())
+        .collect();
 
     let helper = Helper {
         completions: completions,
+        query_completions: query_completions,
     };
     let mut rl = Editor::<Helper>::new();
     rl.set_helper(Some(helper));

--- a/src/bin/dbc.rs
+++ b/src/bin/dbc.rs
@@ -114,6 +114,21 @@ fn main() -> Result<()> {
                     } else {
                         println!("{}", "ERROR: Unsupported command".red());
                     }
+                } else if line.starts_with("@") {
+                    let q = {
+                        let queries = conn.standard_queries();
+                        let v = queries.into_iter().filter(|x| x.name == &line[1..]).nth(0);
+                        v.map(|x| x.query.to_string())
+                    };
+                    match q {
+                        Some(x) => dbc::commands::query::execute_query_and_print_results(
+                            &mut client,
+                            &mut conn,
+                            &x,
+                            1000,
+                        )?,
+                        None => println!("Query not found {}", &line[1..]),
+                    };
                 } else {
                     let limit = client.options.row_limit;
                     dbc::commands::query::execute_query_and_print_results(

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -12,7 +12,7 @@ pub fn execute_query_and_print_results(
     row_limit: usize,
 ) -> Result<()> {
     let query = query.trim().trim_end_matches(";");
-    if query.starts_with("select") {
+    if query.starts_with("select") || query.starts_with("SELECT") {
         client.set_last_select(&query);
         let col_limit = client.options.column_limit;
 

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -43,6 +43,12 @@ pub struct TableRef {
     pub name: String,
 }
 
+#[derive(Clone)]
+pub struct StandardQuery<'a> {
+    pub name: &'a str,
+    pub query: &'a str,
+}
+
 pub trait Connection {
     fn execute(&mut self, statement: &str) -> Result<u64>;
 
@@ -51,6 +57,8 @@ pub trait Connection {
     fn list_tables(&mut self) -> Result<Vec<TableRef>>;
 
     fn prompt(&self) -> String;
+
+    fn standard_queries(&self) -> Vec<StandardQuery>;
 }
 
 pub fn create_connection(

--- a/src/database/ora.rs
+++ b/src/database/ora.rs
@@ -116,4 +116,7 @@ impl Connection for OracleConnection {
         }
         return Ok(v);
     }
+    fn standard_queries(&self) -> Vec<super::StandardQuery> {
+        vec![]
+    }
 }

--- a/src/database/pg.rs
+++ b/src/database/pg.rs
@@ -90,6 +90,49 @@ impl Connection for PgConnection {
 
         return Ok(v);
     }
+    fn standard_queries(&self) -> Vec<super::StandardQuery> {
+        let s = super::StandardQuery {
+            name: "locks",
+            query: "select blocked_locks.pid     AS blocked_pid,
+            blocked_activity.usename  AS blocked_user,
+            blocking_locks.pid     AS blocking_pid,
+            blocking_activity.usename AS blocking_user,
+            blocked_activity.query    AS blocked_statement,
+            blocking_activity.query   AS current_statement_in_blocking_process,
+            blocked_activity.application_name AS blocked_application,
+            blocking_activity.application_name AS blocking_application
+      FROM  pg_catalog.pg_locks         blocked_locks
+       JOIN pg_catalog.pg_stat_activity blocked_activity  ON blocked_activity.pid = blocked_locks.pid
+       JOIN pg_catalog.pg_locks         blocking_locks
+           ON blocking_locks.locktype = blocked_locks.locktype
+           AND blocking_locks.DATABASE IS NOT DISTINCT FROM blocked_locks.DATABASE
+           AND blocking_locks.relation IS NOT DISTINCT FROM blocked_locks.relation
+           AND blocking_locks.page IS NOT DISTINCT FROM blocked_locks.page
+           AND blocking_locks.tuple IS NOT DISTINCT FROM blocked_locks.tuple
+           AND blocking_locks.virtualxid IS NOT DISTINCT FROM blocked_locks.virtualxid
+           AND blocking_locks.transactionid IS NOT DISTINCT FROM blocked_locks.transactionid
+           AND blocking_locks.classid IS NOT DISTINCT FROM blocked_locks.classid
+           AND blocking_locks.objid IS NOT DISTINCT FROM blocked_locks.objid
+           AND blocking_locks.objsubid IS NOT DISTINCT FROM blocked_locks.objsubid
+           AND blocking_locks.pid != blocked_locks.pid
+      JOIN pg_catalog.pg_stat_activity blocking_activity ON blocking_activity.pid = blocking_locks.pid
+     WHERE NOT blocked_locks.GRANTED"
+        };
+        let s2 = super::StandardQuery {
+            name: "queries",
+            query: "SELECT pid, age(clock_timestamp(), query_start), usename, query 
+            FROM pg_stat_activity 
+            WHERE query != '<IDLE>' AND query NOT ILIKE '%pg_stat_activity%' 
+            ORDER BY query_start desc",
+        };
+        let s3 = super::StandardQuery {
+            name: "sizes",
+            query: "select datname, pg_size_pretty(pg_database_size(datname))
+            from pg_database
+            order by pg_database_size(datname) desc",
+        };
+        vec![s, s2, s3]
+    }
 }
 
 fn row_values(row: &Row) -> super::Row {
@@ -99,7 +142,7 @@ fn row_values(row: &Row) -> super::Row {
                 let c = row.columns().iter().nth(i);
                 if let Some(c) = c {
                     match c.type_() {
-                        &Type::TEXT | &Type::VARCHAR => {
+                        &Type::TEXT | &Type::VARCHAR | &Type::NAME => {
                             let s: Option<String> = row.get(i);
                             s
                         }

--- a/src/database/sqlite.rs
+++ b/src/database/sqlite.rs
@@ -91,6 +91,9 @@ impl Connection for SqliteConnection {
             .unwrap();
         Ok(r)
     }
+    fn standard_queries(&self) -> Vec<super::StandardQuery> {
+        vec![]
+    }
 }
 
 fn row_values(row: &Row) -> super::Row {


### PR DESCRIPTION
As a user I want to be able to have standard queries available which are defined per-datebase.

This can include queries to:

* View the current sessions
* Show locking sessions
* Query information about the database, tables, objects

Those queries should be called by prepending them with a `@`. There should be an autocompletion available for them